### PR TITLE
Fix : switch next js templates to standalone

### DIFF
--- a/nextjs/magic-portfolio/next.config.mjs
+++ b/nextjs/magic-portfolio/next.config.mjs
@@ -7,6 +7,7 @@ const withMDX = mdx({
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  output: 'standalone',
   pageExtensions: ["ts", "tsx", "md", "mdx"],
 };
 

--- a/nextjs/nxtlnk/next.config.js
+++ b/nextjs/nxtlnk/next.config.js
@@ -1,5 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+    output: 'standalone',
     reactStrictMode: true,
     swcMinify: true,
     compiler: {

--- a/nextjs/starter/next.config.mjs
+++ b/nextjs/starter/next.config.mjs
@@ -1,5 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  output: 'standalone',
 };
 
 export default nextConfig;


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

(Provide a description of what this PR does.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Next.js build configuration across multiple projects to enable standalone output mode, optimizing deployment efficiency and build performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->